### PR TITLE
Fully vectorised distance calculation

### DIFF
--- a/get_predictions.py
+++ b/get_predictions.py
@@ -100,15 +100,6 @@ def inference_time_create_features(pdb_path, chain="A", secondary_structure=True
     return torch.Tensor(stacked_features)
 
 
-def calc_residue_dist(residue_one, residue_two) :
-    """Returns the C-alpha distance between two residues."""
-    try:
-        diff_vector = residue_one["CA"].coord - residue_two["CA"].coord
-        dist = np.sqrt(np.sum(diff_vector * diff_vector))
-    except:
-        dist = 20.0
-    return dist
-
 def get_model_structure(structure_path, chain='A') -> Bio.PDB.Structure:
     """
     Returns the Bio.PDB.Structure object for a given PDB or MMCIF file

--- a/tests/unit/test_featurisation.py
+++ b/tests/unit/test_featurisation.py
@@ -1,7 +1,20 @@
-import time
+from pathlib import Path
 import Bio.PDB
 import numpy as np
-from get_predictions import get_model_structure, v0_calc_dist_matrix, get_distance
+from get_predictions import get_model_structure, get_distance
+
+REPO_ROOT = Path(__file__).parent.parent.parent.resolve()
+DATA_DIR = REPO_ROOT / "example_files"
+
+
+def calc_residue_dist(residue_one, residue_two) :
+    """Returns the C-alpha distance between two residues."""
+    try:
+        diff_vector = residue_one["CA"].coord - residue_two["CA"].coord
+        dist = np.sqrt(np.sum(diff_vector * diff_vector))
+    except:
+        dist = 20.0
+    return dist
 
 
 def v0_calc_dist_matrix(chain):
@@ -25,8 +38,10 @@ def v0_get_distance(structure_model: Bio.PDB.Structure, chain='A'):
     return x
 
 
-def test_vectorised_distances(pdb_file):
-    model_structure = get_model_structure(pdb_file)
+def test_vectorised_distances():
+    af_id = "AF-A0A1W2PQ64-F1-model_v4"
+    example_structure_path = str(DATA_DIR / f"{af_id}.pdb")
+    model_structure = get_model_structure(example_structure_path)
     expected_distances = v0_get_distance(model_structure)
     distances = get_distance(model_structure)
 


### PR DESCRIPTION
Further significant speedup to distance calculation by making it fully vectorised.

N.B. currently errors in getting CA coordinates from residues are not handled in the new implementation.
The original version had a try: except: clause which set distance to 20.0 if there
was any error in extracting coordinates.

If this is important we should probably try to implement a vectorisable way of handling this issue (e.g. via masking).
Do you have examples where this occurs or have an idea or when it would occur?